### PR TITLE
6-add-support-for-symfony-process-6-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `zbar-php` will be documented in this file
 
 ## Unreleased
 
+- symfony process 6 compatibility.
+
 ## 1.2.0 - 2021-06-03
 - PHP 8 support added.
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-imagick": "*",
-        "symfony/process": "^4.4|^5.0"
+        "symfony/process": "^4.4|^5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0"


### PR DESCRIPTION
This PR adds `^6.0` requirements to the existing requirements for `symfony/process` package.